### PR TITLE
batchify fanout tasks to be robust in production

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -3,7 +3,10 @@
   <component name="ChangeListManager">
     <list default="true" id="d0b95770-f400-4bd7-8722-22b2d0399ce5" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/friendships/services.py" beforeDir="false" afterPath="$PROJECT_DIR$/friendships/services.py" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/newsfeeds/services.py" beforeDir="false" afterPath="$PROJECT_DIR$/newsfeeds/services.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/newsfeeds/tasks.py" beforeDir="false" afterPath="$PROJECT_DIR$/newsfeeds/tasks.py" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/newsfeeds/tests.py" beforeDir="false" afterPath="$PROJECT_DIR$/newsfeeds/tests.py" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/friendships/services.py
+++ b/friendships/services.py
@@ -41,6 +41,11 @@ class FriendshipService():
         ).exists()
 
     @classmethod
+    def get_follower_ids(cls, user_id):
+        friendships = Friendship.objects.filter(to_user_id=user_id)
+        return [f.from_user_id for f in friendships]
+
+    @classmethod
     def get_following_user_id_set(cls, from_user_id):
         key = FOLLOWING_PATTERN.format(user_id=from_user_id)
         user_id_set = cache.get(key)

--- a/newsfeeds/constants.py
+++ b/newsfeeds/constants.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+FANOUT_BATCH_SIZE = 1000 if not settings.TESTING else 3

--- a/newsfeeds/services.py
+++ b/newsfeeds/services.py
@@ -1,14 +1,31 @@
 from newsfeeds.models import NewsFeed
 from utils.cache import USER_NEWSFEED_PATTERN
 from utils.redis_helper import RedisHelper
-from newsfeeds.tasks import fanout_to_followers_task
+from newsfeeds.tasks import fanout_to_followers_main_task
 
 
 class NewsFeedService():
     @classmethod
     def fanout_to_followers(cls, tweet):
+        """
+        Create fanout task in Celery Message Queue
+        Any workers that are monitoring the message queue has chance to take the task
+        In the process, worker will handle 'fanout_to_followers_main_task' ASYNCHRONOUSLY
+        If the fanout takes 1000 seconds in total, the 1000 seconds won't be seen in the user posting
+        .delay will end the process immediately without interrupting other user operations
 
-        fanout_to_followers_task.delay(tweet.id)
+        We have only created one task here. The task information is pushed into the MQ.
+        The task has not really been done yet
+
+        Note:
+            The .delay() only takes arguments that can be serialized by Celery.
+            Since workers are individual processes, which may be on different machines,
+            there is no way for it to know what is on the Web Sever.
+            We can only pass the tweet.id to it and let the worker get exact content/info
+            from the DB.
+            Celery has no idea how to serialize Tweet, so it only allows id as argument
+        """
+        fanout_to_followers_main_task.delay(tweet.id, tweet.user_id)
 
     @classmethod
     def load_newsfeeds_through_cache(cls, user_id):


### PR DESCRIPTION
1. batchify fanout tasks to be robust in production
2. fanout the post to the user immediately to improve user experience
3. fanout to followers as asynchronous tasks
4. asynchronous tasks to be finished as batches to reduce failing risk